### PR TITLE
docs: add Hanzilla Jobs Canadian student resource

### DIFF
--- a/OFFSEASON_README.md
+++ b/OFFSEASON_README.md
@@ -6,6 +6,10 @@ We're back! Use this repo to share and keep track of software, tech, CS, PM, qua
 
 🙏 **Contribute by submitting an [issue](https://github.com/lucianlavric/CanadaTechInternships-Summer2026/issues/new/choose)! See the contribution guidelines [here](./CONTRIBUTING.md)!** 🙏
 
+## Related Canadian student job resources
+
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - a free, daily-updated Canadian student and recent-grad job board covering internships, co-ops, new-grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more.
+
 ---
 
 ## The List 🚴🏔

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This list is maintained collaboratively by Luka and Ali!
 
 This repo is inspired by [Pitt CSC & Simplify Repo](https://github.com/SimplifyJobs/Summer2024-Internships).
 
+## Related Canadian student job resources
+
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - a free, daily-updated Canadian student and recent-grad job board covering internships, co-ops, new-grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more.
+
 ![Visitors](https://api.visitorbadge.io/api/visitors?path=https%3A%2F%2Fgithub.com%2Flucianlavric%2FCanadaTechInternships-Summer2026&labelColor=%23697689&countColor=%23d9e3f0&style=flat-square&labelStyle=upper)
 
 ---


### PR DESCRIPTION
## Summary
- add Hanzilla Jobs as a related Canadian student job-search resource in the summer and off-season README files
- link to the internships/co-op landing page because this repo focuses on Canadian internships and co-ops
- describe it broadly as a free daily-updated Canadian student/recent-grad board across internships, co-ops, new-grad, junior, and entry-level roles

## Test plan
- `git diff --check`

Thanks for maintaining a Canada-specific internship list for students — this is meant as a complementary resource rather than a replacement for the curated table here.
