### PR TITLE
docs: add Hanzilla Jobs resource link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This list is maintained collaboratively by Luka and Ali!
 
 This repo is inspired by [Pitt CSC & Simplify Repo](https://github.com/SimplifyJobs/Summer2024-Internships).
 
+### Related Canadian student job resources
+
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - free daily-updated Canadian student and recent-grad jobs board for internships, co-ops, new-grad, junior, and entry-level roles across tech, engineering, finance, business, sciences, arts, and other fields.
+
 ![Visitors](https://api.visitorbadge.io/api/visitors?path=https%3A%2F%2Fgithub.com%2Flucianlavric%2FCanadaTechInternships-Summer2026&labelColor=%23697689&countColor=%23d9e3f0&style=flat-square&labelStyle=upper)
 
 ---


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs as a related Canadian student job-search resource.
- Links directly to the internships/co-op page for students using this repo.

Hanzilla is a free daily-updated Canadian student/recent-grad jobs board covering internships, co-ops, new-grad, junior, and entry-level roles across tech, engineering, finance, business, sciences, arts, and other fields.

## Test plan
- README-only change
- `git diff --check`
